### PR TITLE
完善重定向返回功能

### DIFF
--- a/src/permission.js
+++ b/src/permission.js
@@ -31,7 +31,7 @@ router.beforeEach(async (to, from, next) => {
         next()
     }
     else {
-        next('/login')
+        next('/login' + `?redirectFrom=${to.path}`)
     }
 })
 

--- a/src/views/auth/Login.vue
+++ b/src/views/auth/Login.vue
@@ -49,7 +49,7 @@ export default {
   name: "Login",
   data() {
     return {
-      redirect: undefined,
+      redirect: this.$route.query.redirectFrom,
       loading: false,
       ruleForm: {
         name: "",


### PR DESCRIPTION
在未认证的情况下访问需要认证的资源，会被自动重定向到/login。在成功认证之后，继续访问原来的路径。


演示：这里在未登录的情况下访问了 `/post/create`。因为没有登录，所以会自动跳转到登录界面。在登录之后，自动继续访问 `/post/create`
![](https://i.loli.net/2021/06/01/bon2kmpzft1OF9j.gif)